### PR TITLE
Add GoReleaser config and fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,22 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
+      - name: Install kustomize
+        run: |
+          curl -sL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Generate CRD manifest
+        run: |
+          cat config/crd/bases/*.yaml > opentalon-operator.crds.yaml
+
+      - name: Generate full install manifest
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          cd config/manager && kustomize edit set image controller=${{ env.REGISTRY }}/opentalon/opentalon-operator:${VERSION}
+          cd ${{ github.workspace }}
+          kustomize build config/default > opentalon-operator.install.yaml
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -62,7 +78,7 @@ jobs:
           VERSION="${VERSION#v}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
-          TAGS=("latest" "${{ github.ref_name }}" "${MAJOR}.${MINOR}")
+          TAGS=("latest" "${{ github.ref_name }}" "v${MAJOR}.${MINOR}")
 
           for tag in "${TAGS[@]}"; do
             echo "Signing ${IMAGE}:${tag}..."

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,88 @@
+version: 2
+
+project_name: opentalon-operator
+
+builds:
+  - id: manager
+    main: ./cmd/main.go
+    binary: manager
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+dockers:
+  - image_templates:
+      - "ghcr.io/opentalon/opentalon-operator:{{ .Tag }}-amd64"
+      - "ghcr.io/opentalon/opentalon-operator:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/opentalon/opentalon-operator:latest-amd64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/opentalon/k8s-operator"
+    goarch: amd64
+
+  - image_templates:
+      - "ghcr.io/opentalon/opentalon-operator:{{ .Tag }}-arm64"
+      - "ghcr.io/opentalon/opentalon-operator:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/opentalon/opentalon-operator:latest-arm64"
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/opentalon/k8s-operator"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/opentalon/opentalon-operator:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/opentalon/opentalon-operator:{{ .Tag }}-amd64"
+      - "ghcr.io/opentalon/opentalon-operator:{{ .Tag }}-arm64"
+
+  - name_template: "ghcr.io/opentalon/opentalon-operator:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/opentalon/opentalon-operator:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/opentalon/opentalon-operator:v{{ .Major }}.{{ .Minor }}-arm64"
+
+  - name_template: "ghcr.io/opentalon/opentalon-operator:latest"
+    image_templates:
+      - "ghcr.io/opentalon/opentalon-operator:latest-amd64"
+      - "ghcr.io/opentalon/opentalon-operator:latest-arm64"
+
+archives:
+  - id: manager
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  github:
+    owner: opentalon
+    name: k8s-operator
+  extra_files:
+    - glob: ./opentalon-operator.crds.yaml
+    - glob: ./opentalon-operator.install.yaml

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,5 @@
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY manager .
+USER 65532:65532
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
- Add .goreleaser.yaml for multi-arch binary builds and Docker image publishing
- Add Dockerfile.goreleaser for GoReleaser's Docker build step
- Generate and upload opentalon-operator.crds.yaml and install.yaml as release assets
- Fix image signing tags to use v-prefixed minor versions