### PR TITLE
Add WebSocket channel ingress, path, CORS origins, and pod annotations

### DIFF
--- a/api/v1alpha1/opentaloninstance_types.go
+++ b/api/v1alpha1/opentaloninstance_types.go
@@ -119,6 +119,11 @@ type OpenTalonInstanceSpec struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// PodAnnotations sets additional annotations on the pod template.
+	// Useful for Prometheus scrape annotations or other integrations.
+	// +optional
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
 	// ServiceAccountName sets a custom service account for the pod.
 	// When empty the operator creates and manages a dedicated service account.
 	// +optional
@@ -306,6 +311,21 @@ type WebSocketChannelConfig struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	Port int32 `json:"port,omitempty"`
+
+	// Path is the HTTP path at which the WebSocket endpoint is served.
+	// +optional
+	// +kubebuilder:default="/ws"
+	Path string `json:"path,omitempty"`
+
+	// CORSOrigins lists the allowed CORS origins for WebSocket connections.
+	// An empty list allows all origins (dev mode).
+	// +optional
+	CORSOrigins []string `json:"corsOrigins,omitempty"`
+
+	// Ingress configures a dedicated Ingress for the WebSocket endpoint.
+	// When omitted the WebSocket is only reachable cluster-internally.
+	// +optional
+	Ingress *IngressSpec `json:"ingress,omitempty"`
 }
 
 // PluginConfig configures a gRPC plugin loaded by OpenTalon.

--- a/internal/controller/opentaloninstance_controller.go
+++ b/internal/controller/opentaloninstance_controller.go
@@ -246,6 +246,17 @@ func (r *OpenTalonInstanceReconciler) reconcileResources(
 		managedResources = append(managedResources, "Ingress/"+ingress.Name)
 	}
 
+	// 7a. WebSocket Ingress (optional) ─────────────────────────────────────────
+	if instance.Spec.Config.Channels != nil {
+		if ws := instance.Spec.Config.Channels.WebSocket; ws != nil && ws.Enabled && ws.Ingress != nil && ws.Ingress.Enabled {
+			wsIngress := resources.BuildWebSocketIngress(instance)
+			if err := r.createOrUpdateIngress(ctx, instance, wsIngress); err != nil {
+				return fmt.Errorf("websocket ingress: %w", err)
+			}
+			managedResources = append(managedResources, "Ingress/"+wsIngress.Name)
+		}
+	}
+
 	// 8. NetworkPolicy (optional) ──────────────────────────────────────────────
 	if instance.Spec.Networking.NetworkPolicy.Enabled {
 		np := resources.BuildNetworkPolicy(instance)

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -136,6 +136,17 @@ func renderConfigYAML(instance *v1alpha1.OpenTalonInstance) string {
 				port = 8081
 			}
 			sb.WriteString(fmt.Sprintf("    port: %d\n", port))
+			wsPath := spec.Channels.WebSocket.Path
+			if wsPath == "" {
+				wsPath = "/ws"
+			}
+			sb.WriteString(fmt.Sprintf("    path: %s\n", yamlString(wsPath)))
+			if len(spec.Channels.WebSocket.CORSOrigins) > 0 {
+				sb.WriteString("    cors_origins:\n")
+				for _, o := range spec.Channels.WebSocket.CORSOrigins {
+					sb.WriteString(fmt.Sprintf("      - %s\n", yamlString(o)))
+				}
+			}
 		}
 
 		sb.WriteString("\n")

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -90,3 +90,82 @@ func BuildIngress(instance *v1alpha1.OpenTalonInstance) *networkingv1.Ingress {
 
 	return ingress
 }
+
+// WebSocketIngressName returns the name of the dedicated WebSocket Ingress.
+func WebSocketIngressName(instance *v1alpha1.OpenTalonInstance) string {
+	return ResourceName(instance) + "-ws"
+}
+
+// BuildWebSocketIngress creates a dedicated Ingress for the WebSocket channel.
+// It merges default WebSocket-friendly annotations (long proxy timeouts) with
+// user-supplied annotations from the channel's ingress spec.
+func BuildWebSocketIngress(instance *v1alpha1.OpenTalonInstance) *networkingv1.Ingress {
+	ws := instance.Spec.Config.Channels.WebSocket
+	wsIngress := ws.Ingress
+
+	wsPort := ws.Port
+	if wsPort == 0 {
+		wsPort = 8081
+	}
+	wsPath := ws.Path
+	if wsPath == "" {
+		wsPath = "/ws"
+	}
+
+	// Default WebSocket annotations for nginx; user annotations can override.
+	annotations := map[string]string{
+		"nginx.ingress.kubernetes.io/proxy-read-timeout":  "3600",
+		"nginx.ingress.kubernetes.io/proxy-send-timeout":  "3600",
+	}
+	for k, v := range wsIngress.Annotations {
+		annotations[k] = v
+	}
+
+	pathType := networkingv1.PathTypeExact
+
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        WebSocketIngressName(instance),
+			Namespace:   instance.Namespace,
+			Labels:      Labels(instance),
+			Annotations: annotations,
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: wsIngress.ClassName,
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: wsIngress.Host,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     wsPath,
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: ResourceName(instance),
+											Port: networkingv1.ServiceBackendPort{
+												Number: wsPort,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if wsIngress.TLSSecretName != "" {
+		ingress.Spec.TLS = []networkingv1.IngressTLS{
+			{
+				Hosts:      []string{wsIngress.Host},
+				SecretName: wsIngress.TLSSecretName,
+			},
+		}
+	}
+
+	return ingress
+}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -73,7 +73,12 @@ func BuildStatefulSet(instance *v1alpha1.OpenTalonInstance, configHash string) *
 		ConfigHashAnnotation: configHash,
 	}
 
-	// Merge user-supplied pod annotations if any are set on the instance.
+	// Merge user-supplied pod annotations from spec.podAnnotations.
+	for k, v := range instance.Spec.PodAnnotations {
+		podAnnotations[k] = v
+	}
+
+	// Also merge annotations from the instance metadata (legacy behaviour).
 	for k, v := range instance.Annotations {
 		if k != ConfigHashAnnotation {
 			podAnnotations[k] = v


### PR DESCRIPTION
- Add path, corsOrigins, and ingress fields to WebSocketChannelConfig
- Render path and cors_origins into the generated config.yaml
- Build a dedicated WebSocket Ingress with long proxy timeouts
- Reconcile the WebSocket Ingress in the controller
- Add spec.podAnnotations for Prometheus scrape annotations and similar