### PR TITLE
Add leader election RBAC marker for coordination.k8s.io leases

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/internal/controller/opentaloninstance_controller.go
+++ b/internal/controller/opentaloninstance_controller.go
@@ -54,6 +54,7 @@ import (
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 // OpenTalonInstanceReconciler reconciles an OpenTalonInstance resource.
 type OpenTalonInstanceReconciler struct {


### PR DESCRIPTION
The kubebuilder RBAC markers were missing the coordination.k8s.io leases permission needed for leader election, causing the operator to fail with RBAC forbidden errors.