### PR TITLE
Fix ClusterRole name mismatch in kustomize RBAC

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -5,3 +5,12 @@ resources:
   - role.yaml
   - role_binding.yaml
   - service_account.yaml
+
+patches:
+  - target:
+      kind: ClusterRole
+      name: manager-role
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: opentalon-operator-manager-role


### PR DESCRIPTION
controller-gen generates the role as "manager-role" but the binding references "opentalon-operator-manager-role". Add a kustomize patch to rename the role so they match.