### PR TITLE
refactor: change plugins from list to named map in CRD

### DIFF
--- a/api/v1alpha1/opentaloninstance_types.go
+++ b/api/v1alpha1/opentaloninstance_types.go
@@ -177,9 +177,9 @@ type ConfigSpec struct {
 	// +optional
 	Channels *ChannelsConfig `json:"channels,omitempty"`
 
-	// Plugins lists gRPC plugin configurations.
+	// Plugins configures Kubernetes-level resources for plugins, keyed by plugin name.
 	// +optional
-	Plugins []PluginConfig `json:"plugins,omitempty"`
+	Plugins map[string]PluginConfig `json:"plugins,omitempty"`
 
 	// State configures SQLite-backed session persistence.
 	// +optional
@@ -333,12 +333,6 @@ type WebSocketChannelConfig struct {
 // belongs in the OpenTalon config.yaml — either via configFrom (external ConfigMap)
 // or via spec.config.extraConfig.
 type PluginConfig struct {
-	// Name is the unique plugin identifier (e.g. "weaviate", "mcp").
-	// Must match the plugin name used in the OpenTalon config.yaml.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
-	Name string `json:"name"`
-
 	// Ingress configures a dedicated Ingress for the plugin's HTTP endpoint.
 	// The plugin must expose an HTTP server (e.g. via http_addr in its config).
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -126,9 +126,9 @@ func (in *ConfigSpec) DeepCopyInto(out *ConfigSpec) {
 	}
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
-		*out = make([]PluginConfig, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = make(map[string]PluginConfig, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 	if in.State != nil {

--- a/charts/opentalon-operator/templates/crds/opentalon.io_opentaloninstances.yaml
+++ b/charts/opentalon-operator/templates/crds/opentalon.io_opentaloninstances.yaml
@@ -3019,8 +3019,7 @@ spec:
                       type: object
                     type: array
                   plugins:
-                    description: Plugins lists gRPC plugin configurations.
-                    items:
+                    additionalProperties:
                       description: |-
                         PluginConfig configures a plugin's Kubernetes-level resources (ingress, service port).
                         The plugin's runtime configuration (source, github/ref, dial_timeout, config map)
@@ -3068,16 +3067,10 @@ spec:
                           - path
                           - port
                           type: object
-                        name:
-                          description: |-
-                            Name is the unique plugin identifier (e.g. "weaviate", "mcp").
-                            Must match the plugin name used in the OpenTalon config.yaml.
-                          minLength: 1
-                          type: string
-                      required:
-                      - name
                       type: object
-                    type: array
+                    description: Plugins configures Kubernetes-level resources for
+                      plugins, keyed by plugin name.
+                    type: object
                   routing:
                     description: Routing configures model selection and fallback behaviour.
                     properties:

--- a/config/crd/bases/opentalon.io_opentaloninstances.yaml
+++ b/config/crd/bases/opentalon.io_opentaloninstances.yaml
@@ -3013,8 +3013,7 @@ spec:
                       type: object
                     type: array
                   plugins:
-                    description: Plugins lists gRPC plugin configurations.
-                    items:
+                    additionalProperties:
                       description: |-
                         PluginConfig configures a plugin's Kubernetes-level resources (ingress, service port).
                         The plugin's runtime configuration (source, github/ref, dial_timeout, config map)
@@ -3062,16 +3061,10 @@ spec:
                           - path
                           - port
                           type: object
-                        name:
-                          description: |-
-                            Name is the unique plugin identifier (e.g. "weaviate", "mcp").
-                            Must match the plugin name used in the OpenTalon config.yaml.
-                          minLength: 1
-                          type: string
-                      required:
-                      - name
                       type: object
-                    type: array
+                    description: Plugins configures Kubernetes-level resources for
+                      plugins, keyed by plugin name.
+                    type: object
                   routing:
                     description: Routing configures model selection and fallback behaviour.
                     properties:

--- a/internal/controller/opentaloninstance_controller.go
+++ b/internal/controller/opentaloninstance_controller.go
@@ -248,11 +248,11 @@ func (r *OpenTalonInstanceReconciler) reconcileResources(
 	}
 
 	// 7b. Plugin Ingress (optional) ────────────────────────────────────────────
-	for _, p := range instance.Spec.Config.Plugins {
+	for name, p := range instance.Spec.Config.Plugins {
 		if p.Ingress != nil && p.Ingress.Enabled {
-			pluginIngress := resources.BuildPluginIngress(instance, p)
+			pluginIngress := resources.BuildPluginIngress(instance, name, p)
 			if err := r.createOrUpdateIngress(ctx, instance, pluginIngress); err != nil {
-				return fmt.Errorf("plugin %s ingress: %w", p.Name, err)
+				return fmt.Errorf("plugin %s ingress: %w", name, err)
 			}
 			managedResources = append(managedResources, "Ingress/"+pluginIngress.Name)
 		}

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -179,7 +179,7 @@ func PluginIngressName(instance *v1alpha1.OpenTalonInstance, pluginName string) 
 
 // BuildPluginIngress creates a dedicated Ingress for a plugin's HTTP endpoint.
 // It rewrites the path prefix so the plugin receives requests at its root.
-func BuildPluginIngress(instance *v1alpha1.OpenTalonInstance, plugin v1alpha1.PluginConfig) *networkingv1.Ingress {
+func BuildPluginIngress(instance *v1alpha1.OpenTalonInstance, name string, plugin v1alpha1.PluginConfig) *networkingv1.Ingress {
 	pi := plugin.Ingress
 
 	annotations := map[string]string{
@@ -196,7 +196,7 @@ func BuildPluginIngress(instance *v1alpha1.OpenTalonInstance, plugin v1alpha1.Pl
 
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        PluginIngressName(instance, plugin.Name),
+			Name:        PluginIngressName(instance, name),
 			Namespace:   instance.Namespace,
 			Labels:      Labels(instance),
 			Annotations: annotations,

--- a/internal/resources/plugin_ingress_test.go
+++ b/internal/resources/plugin_ingress_test.go
@@ -16,9 +16,8 @@ func TestPluginIngress(t *testing.T) {
 		},
 		Spec: v1alpha1.OpenTalonInstanceSpec{
 			Config: v1alpha1.ConfigSpec{
-				Plugins: []v1alpha1.PluginConfig{
-					{
-						Name: "weaviate",
+				Plugins: map[string]v1alpha1.PluginConfig{
+					"weaviate": {
 						Ingress: &v1alpha1.PluginIngressSpec{
 							Enabled:       true,
 							Host:          "opentalon.timly.com",
@@ -42,7 +41,7 @@ func TestPluginIngress(t *testing.T) {
 	}
 
 	// Test BuildPluginIngress
-	ingress := resources.BuildPluginIngress(instance, instance.Spec.Config.Plugins[0])
+	ingress := resources.BuildPluginIngress(instance, "weaviate", instance.Spec.Config.Plugins["weaviate"])
 	if ingress.Name != "opentalon-plugin-weaviate" {
 		t.Errorf("ingress name: expected opentalon-plugin-weaviate, got %s", ingress.Name)
 	}
@@ -121,8 +120,8 @@ func TestPluginIngress_NoIngress(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		Spec: v1alpha1.OpenTalonInstanceSpec{
 			Config: v1alpha1.ConfigSpec{
-				Plugins: []v1alpha1.PluginConfig{
-					{Name: "mcp"},
+				Plugins: map[string]v1alpha1.PluginConfig{
+					"mcp": {},
 				},
 			},
 		},

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -119,12 +119,13 @@ func buildServicePorts(instance *v1alpha1.OpenTalonInstance) []corev1.ServicePor
 	}
 
 	// Plugin HTTP ports.
-	for _, p := range instance.Spec.Config.Plugins {
+	for name, p := range instance.Spec.Config.Plugins {
 		if p.Ingress != nil && p.Ingress.Enabled && p.Ingress.Port > 0 {
+			portName := pluginPortName(name)
 			ports = append(ports, corev1.ServicePort{
-				Name:       fmt.Sprintf("plugin-%s", p.Name),
+				Name:       portName,
 				Port:       p.Ingress.Port,
-				TargetPort: intstr.FromString(fmt.Sprintf("plugin-%s", p.Name)),
+				TargetPort: intstr.FromString(portName),
 				Protocol:   corev1.ProtocolTCP,
 			})
 		}
@@ -142,4 +143,13 @@ func buildServicePorts(instance *v1alpha1.OpenTalonInstance) []corev1.ServicePor
 	}
 
 	return ports
+}
+
+// pluginPortName returns a Kubernetes-safe port name for a plugin (max 15 chars).
+func pluginPortName(name string) string {
+	pn := fmt.Sprintf("plugin-%s", name)
+	if len(pn) > 15 {
+		pn = pn[:15]
+	}
+	return pn
 }

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -15,8 +15,6 @@
 package resources
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -338,12 +336,9 @@ func buildContainerPorts(instance *v1alpha1.OpenTalonInstance) []corev1.Containe
 	}
 
 	// Plugin HTTP ports.
-	for _, plugin := range instance.Spec.Config.Plugins {
+	for name, plugin := range instance.Spec.Config.Plugins {
 		if plugin.Ingress != nil && plugin.Ingress.Enabled && plugin.Ingress.Port > 0 {
-			portName := fmt.Sprintf("plugin-%s", plugin.Name)
-			if len(portName) > 15 {
-				portName = portName[:15]
-			}
+			portName := pluginPortName(name)
 			ports = append(ports, corev1.ContainerPort{
 				Name:          portName,
 				ContainerPort: plugin.Ingress.Port,


### PR DESCRIPTION
Change spec.config.plugins from []PluginConfig (list with name field) to map[string]PluginConfig (keyed by plugin name), matching the same pattern used by spec.config.channels.

Before:
  plugins:
    - name: weaviate ingress: ...

After:
  plugins:
    weaviate: ingress: ...